### PR TITLE
Link to presskit logo

### DIFF
--- a/content/verein/contents.lr
+++ b/content/verein/contents.lr
@@ -34,6 +34,9 @@ Im folgenden Abschnitt stellen wir die Logo-Datei der Toolbox Bodensee e.V. als 
 
 Zum herunterladen der Bilddateien klicken Sie mit einem Rechtsklick auf das untenstehende Bild und wählen Sie im geöffneten Kontextmenü den Eintrag “Link speichern unter…”.
 
+
+Die Logos sind auch auf [GitHub](https://github.com/ToolboxBodensee/presskit) verfügbar.
+
 <h3>Rechtliche Hinweise</h3>
 
 


### PR DESCRIPTION
Places a link to github.com/ToolboxBodensee/presskit on the "Verein" page