### PR TITLE
Docker support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
-
-language: python
-python: 3.6
+service:
+  - docker
 cache:
   directories:
-    - $HOME/.cache/pip
     - $HOME/.cache/lektor/builds
-install: "make install"
-script: "make build"
+install: "make docker-pull"
+script: "make docker-build"
 before_deploy: "echo 'c3woc.de ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBC5NslYj+wtriBuKIxJfDRm9E2hnlstWR8durQ6pKvVvP7wjcoXIyAxe41GvJ9SoEhSjF7oVlzlw+zAkzl5WOZ4=' > ~/.ssh/known_hosts"
 deploy:
   provider: script
-  script: "make deploy"
+  script: "make docker-deploy"
 after_success:
     - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then deployment/deploy_pullrequest.sh; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
-
 language: python
 python: 3.6
 cache:
   directories:
     - $HOME/.cache/pip
     - $HOME/.cache/lektor/builds
-install: "make install"
-script: "make build"
+install: "pip install Lektor"
+script: "lektor build"
 before_deploy: "echo 'c3woc.de ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBC5NslYj+wtriBuKIxJfDRm9E2hnlstWR8durQ6pKvVvP7wjcoXIyAxe41GvJ9SoEhSjF7oVlzlw+zAkzl5WOZ4=' > ~/.ssh/known_hosts"
 deploy:
   provider: script
-  script: "make deploy"
+  script: "lektor deploy --key $LEKTOR_DEPLOY_KEY toolbox"
 after_success:
     - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then deployment/deploy_pullrequest.sh; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ service:
 cache:
   directories:
     - $HOME/.cache/lektor/builds
+    - $HOME/.cache/docker
 install: "make docker-pull"
 script: "make docker-build"
 before_deploy: "echo 'c3woc.de ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBC5NslYj+wtriBuKIxJfDRm9E2hnlstWR8durQ6pKvVvP7wjcoXIyAxe41GvJ9SoEhSjF7oVlzlw+zAkzl5WOZ4=' > ~/.ssh/known_hosts"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
+
 language: python
 python: 3.6
 cache:
   directories:
     - $HOME/.cache/pip
     - $HOME/.cache/lektor/builds
-install: "pip install Lektor"
-script: "lektor build"
+install: "make install"
+script: "make build"
 before_deploy: "echo 'c3woc.de ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBC5NslYj+wtriBuKIxJfDRm9E2hnlstWR8durQ6pKvVvP7wjcoXIyAxe41GvJ9SoEhSjF7oVlzlw+zAkzl5WOZ4=' > ~/.ssh/known_hosts"
 deploy:
   provider: script
-  script: "lektor deploy --key $LEKTOR_DEPLOY_KEY toolbox"
+  script: "make deploy"
 after_success:
     - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then deployment/deploy_pullrequest.sh; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
-service:
-  - docker
+
+language: python
+python: 3.6
 cache:
   directories:
+    - $HOME/.cache/pip
     - $HOME/.cache/lektor/builds
-    - $HOME/.cache/docker
-install: "make docker-pull"
-script: "make docker-build"
+install: "make install"
+script: "make build"
 before_deploy: "echo 'c3woc.de ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBC5NslYj+wtriBuKIxJfDRm9E2hnlstWR8durQ6pKvVvP7wjcoXIyAxe41GvJ9SoEhSjF7oVlzlw+zAkzl5WOZ4=' > ~/.ssh/known_hosts"
 deploy:
   provider: script
-  script: "make docker-deploy"
+  script: "make deploy"
 after_success:
     - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then deployment/deploy_pullrequest.sh; fi'

--- a/Makefile
+++ b/Makefile
@@ -52,5 +52,5 @@ docker-deploy: docker-build
 docker-shell: docker-pull
 	$(DOCKER_RUN) $(EXPORTED_PORTS) $(IMAGE) /bin/sh
 
-docker-server: docker-build
+docker-server: docker-pull
 	$(DOCKER_RUN) $(EXPORTED_PORTS) $(IMAGE) lektor server -h 0.0.0.0

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,32 @@ deploy:
 
 server:
 	lektor server $(LEKTOR_SERVER_FLAGS)
+
+## Docker stuff
+IMAGE:=toolboxbodensee/lektor:latest
+
+CACHE:=$(HOME)/.cache
+CACHE_VOL:=-v $(CACHE)/lektor:/root/.cache/lektor
+SOURCE_VOL:=-v $(PWD):/opt/lektor
+
+DOCKER_FLAGS:=--rm -it
+DEPLOY_FLAGS:=-e LEKTOR_DEPLOY_KEY -v $(HOME)/.ssh/known_hosts:/root/.ssl/known_hosts
+
+EXPORTED_PORTS=-p 5000:5000
+
+DOCKER_RUN:=docker run $(DOCKER_FLAGS) $(SOURCE_VOL) $(CACHE_VOL)
+
+docker-pull:
+	docker pull $(IMAGE)
+
+docker-build: docker-pull
+	$(DOCKER_RUN) $(IMAGE) make build
+
+docker-deploy: docker-build
+	$(DOCKER_RUN) $(DEPLOY_FLAGS) $(IMAGE) make deploy
+
+docker-shell: docker-pull
+	$(DOCKER_RUN) $(EXPORTED_PORTS) $(IMAGE) /bin/sh
+
+docker-server:
+	$(DOCKER_RUN) $(EXPORTED_PORTS) $(IMAGE) lektor server -h 0.0.0.0

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ CACHE:=$(HOME)/.cache
 CACHE_VOL:=-v $(CACHE)/lektor:/root/.cache/lektor
 SOURCE_VOL:=-v $(PWD):/opt/lektor
 
+DOCKER_CACHE_DIR:=$(CACHE)/docker
+DOCKER_CACHE:=$(DOCKER_CACHE_DIR)/lektor.tar.gz
+
 DOCKER_FLAGS:=--rm -it
 DEPLOY_FLAGS:=-e LEKTOR_DEPLOY_KEY -v $(HOME)/.ssh/known_hosts:/root/.ssl/known_hosts
 
@@ -25,8 +28,12 @@ EXPORTED_PORTS=-p 5000:5000
 
 DOCKER_RUN:=docker run $(DOCKER_FLAGS) $(SOURCE_VOL) $(CACHE_VOL)
 
-docker-pull:
-	docker pull $(IMAGE)
+"$(DOCKER_CACHE_DIR)":
+	mkdir -p "$(DOCKER_CACHE_DIR)"
+
+docker-pull: "$(DOCKER_CACHE_DIR)"
+	if [ -f "$(DOCKER_CACHE)" ]; then gzip -dc "$(DOCKER_CACHE)" | docker load; fi
+	docker pull $(IMAGE) && docker save $(IMAGE) | gzip > "$(DOCKER_CACHE)"
 
 docker-build: docker-pull
 	$(DOCKER_RUN) $(IMAGE) make build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+LEKTOR_SERVER_FLAGS=-h 127.0.0.1
+
+all: build
+
+install:
+	pip install lektor
+
+build: install
+	lektor build
+
+deploy:
+	lektor deploy --key $(LEKTOR_DEPLOY_KEY) toolbox
+
+server:
+	lektor server $(LEKTOR_SERVER_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ CACHE:=$(HOME)/.cache
 CACHE_VOL:=-v $(CACHE)/lektor:/home/lektor/.cache/lektor
 SOURCE_VOL:=-v $(PWD):/opt/lektor
 
-DOCKER_CACHE_DIR:=$(CACHE)/docker
-DOCKER_CACHE:=$(DOCKER_CACHE_DIR)/lektor.tar.gz
+# DOCKER_CACHE_DIR:=$(CACHE)/docker
+# DOCKER_CACHE:=$(DOCKER_CACHE_DIR)/lektor.tar.gz
 
 DOCKER_FLAGS:=--rm -it
 DEPLOY_FLAGS:=-e LEKTOR_DEPLOY_KEY -v $(HOME)/.ssh/known_hosts:/root/.ssl/known_hosts
@@ -36,12 +36,14 @@ EXPORTED_PORTS=-p 5000:5000
 
 DOCKER_RUN:=docker run $(DOCKER_FLAGS) $(SOURCE_VOL) $(CACHE_VOL)
 
-"$(DOCKER_CACHE_DIR)":
-	mkdir -p "$(DOCKER_CACHE_DIR)"
+# "$(DOCKER_CACHE_DIR)":
+# 	mkdir -p "$(DOCKER_CACHE_DIR)"
 
-docker-pull: "$(DOCKER_CACHE_DIR)"
-	if [ -f "$(DOCKER_CACHE)" ]; then gzip -dc "$(DOCKER_CACHE)" | docker load; fi
-	docker pull $(IMAGE) && docker save $(IMAGE) | gzip > "$(DOCKER_CACHE)"
+# docker-pull: "$(DOCKER_CACHE_DIR)"
+docker-pull:
+	# if [ -f "$(DOCKER_CACHE)" ]; then gzip -dc "$(DOCKER_CACHE)" | docker load; fi
+	# docker pull $(IMAGE) && docker save $(IMAGE) | gzip > "$(DOCKER_CACHE)"
+	docker pull $(IMAGE)
 
 docker-build: docker-pull
 	$(DOCKER_RUN) $(IMAGE) make build

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,7 @@ LEKTOR_SERVER_FLAGS=-h 127.0.0.1
 
 all: build
 
-install:
-	pip install lektor
-
-build: install
+build:
 	lektor build
 
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -49,5 +49,5 @@ docker-deploy: docker-build
 docker-shell: docker-pull
 	$(DOCKER_RUN) $(EXPORTED_PORTS) $(IMAGE) /bin/sh
 
-docker-server:
+docker-server: docker-build
 	$(DOCKER_RUN) $(EXPORTED_PORTS) $(IMAGE) lektor server -h 0.0.0.0

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@ LEKTOR_SERVER_FLAGS=-h 127.0.0.1
 
 all: build
 
-build:
+sass:
+	sassc ./assets/sass/main.scss ./assets/css/main.css
+	sassc ./assets/sass/ie9.scss ./assets/css/ie9.css
+
+build: sass
 	lektor build
 
 deploy:
@@ -12,7 +16,8 @@ server:
 	lektor server $(LEKTOR_SERVER_FLAGS)
 
 ## Docker stuff
-IMAGE:=toolboxbodensee/lektor:latest
+IMAGE_TAG:=v1.1.0
+IMAGE:=toolboxbodensee/lektor:$(IMAGE_TAG)
 
 CACHE:=$(HOME)/.cache
 CACHE_VOL:=-v $(CACHE)/lektor:/root/.cache/lektor

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@ server:
 	lektor server $(LEKTOR_SERVER_FLAGS)
 
 ## Docker stuff
-IMAGE_TAG:=v1.1.0
+IMAGE_TAG:=v1.2.0
 IMAGE:=toolboxbodensee/lektor:$(IMAGE_TAG)
 
 CACHE:=$(HOME)/.cache
-CACHE_VOL:=-v $(CACHE)/lektor:/root/.cache/lektor
+CACHE_VOL:=-v $(CACHE)/lektor:/home/lektor/.cache/lektor
 SOURCE_VOL:=-v $(PWD):/opt/lektor
 
 DOCKER_CACHE_DIR:=$(CACHE)/docker

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ sass:
 	sassc ./assets/sass/main.scss ./assets/css/main.css
 	sassc ./assets/sass/ie9.scss ./assets/css/ie9.css
 
+install:
+	pip install lektor
+
 build: sass
 	lektor build
 

--- a/README.md
+++ b/README.md
@@ -127,3 +127,6 @@ make docker-build # baut die Assets und die lektor cache (lektor build)
 make docker-server # führt den Lektor Server auf localhost:5000 aus
 make docker-shell # führt eine Shell aus innerhalb des Containers. Dies kann man zum Gebuggen genutzt werden.
 ```
+
+**Tipp:** Zum Verwenden von docker muss ``docker`` installiert sein und als Service gestartet sein. Weitere Hinweise dazu u.a. auf [wiki.archlinux.org](https://wiki.archlinux.org/index.php/docker#Installation).
+

--- a/README.md
+++ b/README.md
@@ -115,18 +115,17 @@ make sass
 Docker
 ------------------------
 
-Hat man auf seiner Host kein python oder will man zusätzliche Software installieren, so steht ein Docker Image `toolboxbodensee/lektor:latest` zur Verfügung.
+Hat man auf seiner Host kein python oder will man *keine* zusätzliche Software installieren, so steht ein Docker Image `toolboxbodensee/lektor:latest` zur Verfügung.
 
 Damit lässt sich das Projekt innerhalb eines *Containers* bauen und sogar den lektor server ausführen.
 
-Zur Einfachheit stehen mehrere *make* **docker-** Befehle zur Verfügung. Das Projektordner sowie die lektor cache `.cache/lektor` werden als Volume der Container angehängt.
+Zur Einfachheit stehen mehrere *make* **docker-** Befehle zur Verfügung. Der Projektordner sowie die lektor cache `.cache/lektor` werden als Volume zu der Container angehängt.
 
 ```bash
 make docker-pull # lädt die Lektor Docker Image vom Docker Hub herunter
 make docker-build # baut die Assets und die lektor cache (lektor build)
 make docker-server # führt den Lektor Server auf localhost:5000 aus
-make docker-shell # führt eine Shell aus innerhalb des Containers. Dies kann man zum Gebuggen genutzt werden.
+make docker-shell # führt eine Shell aus innerhalb des Containers. Diese kann man zum Debuggen nutzen.
 ```
 
 **Tipp:** Zum Verwenden von docker muss ``docker`` installiert sein und als Service gestartet sein. Weitere Hinweise dazu u.a. auf [wiki.archlinux.org](https://wiki.archlinux.org/index.php/docker#Installation).
-

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Webseite übersetzen
 ------------------------
 
 Lektor bietet in der Admin-Oberfläche die Möglichkeit die Toolbox Webseite auf englisch zu übersetzen.
-Diese Funktion befindet sich unter dem Punkt ``Alternative``. 
+Diese Funktion befindet sich unter dem Punkt ``Alternative``.
 Als Übersetzer mit guten Ergebnissen kann man beispielsweise [deepl](https://www.deepl.com) verwenden.<br/>
-Links auf Seiten haben in der Englischen Version ein ``/en/`` vor der Adresse. 
+Links auf Seiten haben in der Englischen Version ein ``/en/`` vor der Adresse.
 So wird ``https://toolbox-bodensee.de/projekte/c3woc/`` zu ``https://toolbox-bodensee.de/en/projekte/c3woc/``.
 
 Fork aktuell halten ohne neu zu forken
@@ -77,7 +77,7 @@ Es gibt zwei Möglichkeiten Pull-Requests zu reviewen:
 
 ```bash
 # ID des Pull Request eintragen
-PULLREQUEST=42 
+PULLREQUEST=42
 # Git Repository clonen
 git clone --depth=30 https://github.com/ToolboxBodensee/toolbox-webseite.git toolbox-pull-request
 # In das Repo navigieren
@@ -109,5 +109,21 @@ Das vereinfacht die Verständlichkeit der einzelnen Design Elemente
 und ermöglicht auch das anpassen des Designs durch das simple verändern weniger variablen.
 Example use:
 ```bash
-sassc assets/sass/main.scss > assets/css/main.css
+make sass
+```
+
+Docker
+------------------------
+
+Hat man auf seiner Host kein python oder will man zusätzliche Software installieren, so steht ein Docker Image `toolboxbodensee/lektor:latest` zur Verfügung.
+
+Damit lässt sich das Projekt innerhalb eines *Containers* bauen und sogar den lektor server ausführen.
+
+Zur Einfachheit stehen mehrere *make* **docker-** Befehle zur Verfügung. Das Projektordner sowie die lektor cache `.cache/lektor` werden als Volume der Container angehängt.
+
+```bash
+make docker-pull # lädt die Lektor Docker Image vom Docker Hub herunter
+make docker-build # baut die Assets und die lektor cache (lektor build)
+make docker-server # führt den Lektor Server auf localhost:5000 aus
+make docker-shell # führt eine Shell aus innerhalb des Containers. Dies kann man zum Gebuggen genutzt werden.
 ```

--- a/README.md
+++ b/README.md
@@ -128,4 +128,6 @@ make docker-server # führt den Lektor Server auf localhost:5000 aus
 make docker-shell # führt eine Shell aus innerhalb des Containers. Diese kann man zum Debuggen nutzen.
 ```
 
-**Tipp:** Zum Verwenden von docker muss ``docker`` installiert sein und als Service gestartet sein. Weitere Hinweise dazu u.a. auf [wiki.archlinux.org](https://wiki.archlinux.org/index.php/docker#Installation).
+**Tipp:** Zum Verwenden von docker muss ``docker`` installiert sein und als Service gestartet sein.<br/>
+Außerdem muss dein User zur Gruppe docker gehören und sollte nicht als root ausgeführt werden!<br/>
+Weitere Hinweise dazu u.a. auf [wiki.archlinux.org](https://wiki.archlinux.org/index.php/docker#Installation).


### PR DESCRIPTION
Für die Leute die keine Zusätzliche Software auf ihren Host installieren möchten, gibt es nun die Möglichkeit Docker zu nutzen um die Webseite weiterzuentwickeln.

Damit man nicht jedes mal lange Docker Befehle eintippen muss, gibts die neue Makefile. So kann man zum Beispiel mit `make docker-server` den *lektor server* starten oder mit `make docker-shell` eine Shell innerhalb des Containers starten welches das Debuggen vereinfachen sollte.

Travis wurde auch auf docker umgestellt, sodass die Webseite in einem Docker Container gebaut und deployed wird. Das ermöglicht zukünftig die Integration weiterer Tools wie zum Beispiel *Webpack*

partially fixes #87