### PR TITLE
mark external links

### DIFF
--- a/content/contents+en.lr
+++ b/content/contents+en.lr
@@ -35,6 +35,8 @@ icons_2_2: Hacking
 ---
 icons_2_3: We see ourselves as hackers according to the principles of the Chaos Computer Club and act accordingly according to the [Hacker Ethics](https://www.ccc.de/en/hackerethics).
 ---
+icons_2_url: /
+---
 icons_3_1: fa-cogs
 ---
 icons_3_2: Handicrafts

--- a/content/contents.lr
+++ b/content/contents.lr
@@ -33,6 +33,8 @@ icons_2_1: fa-keyboard
 ---
 icons_2_2: Hacken
 ---
+icons_2_url: /
+---
 icons_2_3: Wir verstehen uns als Hacker nach den Prinzipien des Chaos Computer Clubs und handeln dem entsprechend nach der [Hackerethik](https://www.ccc.de/de/hackerethics).
 ---
 icons_3_1: fa-cogs

--- a/webpack/src/scss/parts/_basic.scss
+++ b/webpack/src/scss/parts/_basic.scss
@@ -80,6 +80,16 @@ a {
     color: _palette(accent1) !important;
     border-bottom-color: transparent;
   }
+  &:not([href*='./']){
+    &:not([href*='toolbox-bodensee.de']){
+      &:not([href^='#']) {
+        &:not([href^='/']):after {
+          font-family: 'FontAwesome';
+          content: " \f08e";
+        }
+      }
+    }
+  }
 }
 
 strong,
@@ -215,4 +225,3 @@ pre {
 .align-right {
   text-align: right;
 }
-

--- a/webpack/src/scss/parts/_icon.scss
+++ b/webpack/src/scss/parts/_icon.scss
@@ -5,6 +5,16 @@
   border-bottom: none;
   position: relative;
 
+  &:not([href*='./']){
+    &:not([href*='toolbox-bodensee.de']){
+      &:not([href^='#']) {
+        &:not([href^='/']):after {
+          content: "";
+        }
+      }
+    }
+  }
+
   > .label {
     display: none;
   }
@@ -43,4 +53,3 @@
     margin-left: $i * 1px;
   }
 }
-


### PR DESCRIPTION
externe links werden nun automatisch als solche angezeigt. Icons wie die social media icons habe ich hiervon ausgeschlossen, da die Markierung dort seltsam aussehen würde

![Bildschirmfoto vom 2019-04-07 14-51-23](https://user-images.githubusercontent.com/44199644/55683854-b45aab80-5944-11e9-811b-933a6df9bfce.png)
![Bildschirmfoto vom 2019-04-07 14-51-15](https://user-images.githubusercontent.com/44199644/55683860-ce948980-5944-11e9-8851-d671e1603048.png)

