### PR TITLE
Google plus removed [en]

### DIFF
--- a/content/kontakt/contents+en.lr
+++ b/content/kontakt/contents+en.lr
@@ -92,9 +92,6 @@ Of course you can also find us on different pages on the internet. For example h
 <td>Hackerspaces.org</td>
 <td><a href="https://wiki.hackerspaces.org/Toolbox_Bodensee_e.V." target="_blank" rel="noopener">Toolbox_Bodensee_e.V.</a></td>
 </tr><tr>
-<td>Google Plus</td>
-<td><a href="https://plus.google.com/107375280456568167018" target="_blank" rel="noopener">Toolbox_Bodensee_e.V.</a></td>
-</tr><tr>
 <td>MeetUp</a>
 <td><a href="https://www.meetup.com/de-DE/Toolbox-Bodensee/"  target="_blank" rel="noopener">Toolbox-Bodensee</a></td>
 </tr><tr>


### PR DESCRIPTION
Removed g+ from the english version of the kontakt page