### PR TITLE
Add RSS Feed to startpage

### DIFF
--- a/templates/feed_blog.xml
+++ b/templates/feed_blog.xml
@@ -14,11 +14,11 @@ set search = "blog" %}
   </author>{%
   set pages = site.query('/blog').include_undiscoverable(true).all() %}{%
   for page in pages %}{% if not page._hidden %}
-  <entry xml:base="{{ baseurl }}{{ search }}/{{ page._id }}/">
+  <entry xml:base="{{ baseurl }}">
     <title type="text">{{ page.title }}</title>
     <id>{{ baseurl }}{{ search }}/{{ page._id }}</id>
     <updated>{{ page.pub_date|datetimeformat('YYYY-MM-ddThh:mm:ss') }}Z</updated>
-    <link href="{{ search }}/{{ page._id }}/" xml:base="{{ baseurl }}" />
+    <link href="{{ search }}/{{ page._id }}/" />
     <author>
       <name>{% if page.author %}{{ page.author }}{% else %}Toolbox{% endif %}</name>
     </author>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -8,6 +8,13 @@ set ausnahmezustand = False
     <meta property="og:title" content="{{ this.title }}"/>
     <meta property="og:type" content="website"/>
     <meta property="og:image" content="https://toolbox-bodensee.de/images/og-image.png"/>
+    <link href="https://{{ fqdn }}/feed_blog.xml" rel="alternate" title="Neues aus der Toolbox" type="application/rss+xml">
+    <link href="https://{{ fqdn }}/en/feed_blog.xml" rel="alternate" title="News from Toolbox [EN]" type="application/rss+xml">
+    <link href="https://{{ fqdn }}/sxu/feed_blog.xml" rel="alternate" title="Neujes ous da Toolbox [Säggsch]" type="application/rss+xml">
+    <link href="https://{{ fqdn }}/feed_projekte.xml" rel="alternate" title="Projekte" type="application/rss+xml">
+    <link href="https://{{ fqdn }}/en/feed_projekte.xml" rel="alternate" title="Projects [EN]" type="application/rss+xml">
+    <link href="https://{{ fqdn }}/sxu/feed_projekte.xml" rel="alternate" title="Brohjeggde [Säggsch]" type="application/rss+xml">
+    <link href="https://c3woc.de/feed_rezepte.xml" rel="alternate" title="Waffelrezepte" type="application/rss+xml">
     <meta name="viewport" content="width=device-width, initial-scale=1" />{%
     if '/css/main.min.css'|asseturl == empty %}
     <link rel="stylesheet" href="{{ '/css/font-awesome.min.css'|asseturl }}" />


### PR DESCRIPTION
RSS Reader können selbstständig die Feedurl finden, wenn man ihnen sagt, wo sie suchen sollen. 