### PR TITLE
do not minify minified files

### DIFF
--- a/configs/jsminify.ini
+++ b/configs/jsminify.ini
@@ -1,3 +1,4 @@
 source_dir = assets/js/
 output_dir = assets/js/
 name_prefix = .min
+excluded_assets = *.min.js

--- a/toolbox-webseite.lektorproject
+++ b/toolbox-webseite.lektorproject
@@ -29,5 +29,5 @@ url_prefix = /sxu/
 locale = de
 
 [packages]
-lektor-jsminify = 1.1
+lektor-jsminify = 1.3
 lektor-scsscompile = 1.1


### PR DESCRIPTION
bereits minifizierte dateien enden jetzt alle mit .min.js und werden mit Hilfe von unix shell wildcards ignoriert wie man das bereits global in der Projekt file kennt welche assets auf den server gelegt werden ;)
https://github.com/maxbachmann/lektor-JSminify/commit/e9d9fef7e6219aaeb172169ecdb0015a4805787b