### PR TITLE
add pre-commit hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ install:
 	fi
 	pip3 install wheel --user
 	pip3 install lektor --user
+	./setup/install-pre-commit.sh
 
 
 build:

--- a/setup/install-pre-commit.sh
+++ b/setup/install-pre-commit.sh
@@ -1,0 +1,21 @@
+
+#!/bin/sh
+# This script installs a pre-commit hook to enforce the correct use of spaces and tabs for this project
+
+GIT_DIR=`git rev-parse --git-common-dir 2> /dev/null`
+
+if [ "$GIT_DIR" == "" ]; then
+  echo "This does not appear to be a git repo."
+  exit 1
+fi
+
+if [ -f "$GIT_DIR/hooks/pre-commit" ]; then
+  rm $GIT_DIR/hooks/pre-commit
+fi
+
+cp $GIT_DIR/../setup/pre-commit.hook $GIT_DIR/hooks/pre-commit
+
+echo
+echo "You're all set! Happy hacking!"
+
+exit 0

--- a/setup/pre-commit.hook
+++ b/setup/pre-commit.hook
@@ -1,0 +1,59 @@
+#!/bin/sh
+hard_limit=$(git config hooks.filesizehardlimit)
+: ${hard_limit:=100000}
+
+if git-rev-parse --verify HEAD >/dev/null 2>&1 ; then
+   against=HEAD
+else
+   # Initial commit: diff against an empty tree object
+   against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+git diff-index --check --cached $against
+err=$?
+
+if [ $err -gt 0 ]; then
+  echo "Your spaces don't agree with your core.whitespace rules."
+  echo "You can commit with -n to bypass this pre-commit hook."
+  exit $err
+fi
+
+
+list_new_or_modified_files()
+{
+    git diff --staged --name-status|sed -e '/^D/ d; /^D/! s/.\s\+//'
+}
+
+unmunge()
+{
+    local result="${1#\"}"
+    result="${result%\"}"
+    env echo -e "$result"
+}
+
+check_file_size()
+{
+    n=0
+    while read -r munged_filename
+    do
+        f="$(unmunge "$munged_filename")"
+        h=$(git ls-files -s "$f"|cut -d' ' -f 2)
+        s=$(git cat-file -s "$h")
+        if [ "$s" -gt $hard_limit ]
+        then
+            env echo -E 1>&2 "ERROR: hard size limit ($hard_limit) exceeded: $munged_filename ($s)"
+            n=$((n+1))
+        fi
+    done
+
+    [ $n -eq 0 ]
+}
+
+list_new_or_modified_files | check_file_size
+err=$?
+
+if [ $err -gt 0 ]; then
+  echo "For binary files you should use git lfs."
+  echo "You can commit with -n to bypass this pre-commit hook."
+  exit $err
+fi


### PR DESCRIPTION
fügt bei make install eine pre-commit hook ein, die vor jedem commit prüft ob:
- die whitespaces in Ordnung sind (keine leerzeichen eol, keine leeren zeilen eof und keine leerzeichen vor tabs am Anfang von Zeilen)
- Erlaubt nur Dateigrößen bis 100kb, wobei der Rest eine Warnung bekommt git lfs zu benutzen (wenn doch mal eine datei größer ist, die nicht in den large file storage soll kann mit -n die hook ignoriert werden, wobei darauf ebenfalls hingewisen wird)