### PR TITLE
Update toolbox-webseite.lektorproject

### DIFF
--- a/toolbox-webseite.lektorproject
+++ b/toolbox-webseite.lektorproject
@@ -30,4 +30,4 @@ locale = de
 
 [packages]
 lektor-jsminify = 1.4
-lektor-scsscompile = 1.2.2
+lektor-scsscompile = 1.2.3


### PR DESCRIPTION
Bei Imports wurde bisher geschaut ob bei
```css
@import 'test';
```
test, test.scss, _test, _test.scss existiert.
Prüft jetzt auch ob
test.css, _test.css existieren, da auch css eingebunden werden kann

**Btw kleiner Hinweis zum Einbinden von css und scss in libsass**
Zu beachten ist hier, dass css OHNE den Dateinamen eingebunden werden muss bei libsass.
dh
```css
@import 'test'
```
importiert test, _test, test.css oder _test.css, sowie test.scss und _test.scss

```css
@import 'test.css'
```
wird jedoch beim compilieren umgewandelt in
```css
@import url('test.css')
```

im Unterschied dazu kann scss auch mit Dateiendung eingebunden werden:
```css
@import 'test.scss'
```

Weiterhin können imports auch aufgelistet werden:
```css
@import
'test',
'test2';
```