### PR TITLE
Specify responsibilities of @ottojo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,15 @@
 # Code Owners of Toolbox Website
 # Interested in all parts of the Toolbox website:
-* @DO1JLR @maxbachmann @ottojo @DEvil0000 @fbsb @blaues0cke @rtt-mmk @drwuro
+* @DO1JLR @maxbachmann @DEvil0000 @fbsb @blaues0cke @rtt-mmk @drwuro
 # interested in the content of the website
-/content/ @haekelhexe @tschanne @drwuro @205er @bodensee @oldwired @phschoen @DO1JLR @maxbachmann @ottojo @DEvil0000 @fbsb @blaues0cke @rtt-mmk 
+/content/ @haekelhexe @tschanne @drwuro @205er @bodensee @oldwired @phschoen @DO1JLR @maxbachmann @DEvil0000 @fbsb @blaues0cke @rtt-mmk 
 # interested in game developement content
-/content/projekte/spieleentwicklung/ @maluramichael @haekelhexe @tschanne @drwuro @205er @bodensee @oldwired @phschoen @DO1JLR @maxbachmann @ottojo @DEvil0000 @fbsb @blaues0cke @rtt-mmk 
+/content/projekte/spieleentwicklung/ @maluramichael @haekelhexe @tschanne @drwuro @205er @bodensee @oldwired @phschoen @DO1JLR @maxbachmann @DEvil0000 @fbsb @blaues0cke @rtt-mmk 
 # Need to contribute some website content bevor becoming a CODEOWNER
 # @davidblumer
+
+# Responsible for project "LED-Steuerung"
+/content/projekte/neopixel-led-pcb/ @ottojo
+
+# Responsible for project "Toolboxplane"
+/content/projekte/toolboxplane/     @ottojo


### PR DESCRIPTION
remove @ottojo from generic codeowners, add @ottojo to toolboxplane and neopixel-led-pcb