### PR TITLE
add js minify plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 LEKTOR_SERVER_FLAGS=-h 127.0.0.1
 # prettify html output, minify javascript assets, compile scss assets
-LEKTOR_PLUGIN_FLAGS=-f scss
+LEKTOR_PLUGIN_FLAGS=-f jsminify -f scss
 
 all: build
 

--- a/configs/jsminify.ini
+++ b/configs/jsminify.ini
@@ -1,4 +1,4 @@
-source_dir = assets/js/
+source_dir = themes/lektor-theme-landed/assets/js/
 output_dir = assets/js/
 name_prefix = .min
 excluded_assets = *.min.js

--- a/toolbox-webseite.lektorproject
+++ b/toolbox-webseite.lektorproject
@@ -31,3 +31,4 @@ locale = de
 
 [packages]
 lektor-scss = 1.3.5
+lektor-jsminify = 1.4.1


### PR DESCRIPTION
Behebt #465 teilweise. Die asseturl wird jetzt korrekt aufgelöst, da es die Datei jetzt gibt
Weiterhin wird die Karte jedoch nicht angezeigt. Das liegt dann aber nicht mehr an der asseturl (ist aber ebenfalls kaputt seit https://github.com/ToolboxBodensee/toolbox-webseite/pull/447)

@re4jh alle Dateien die es hier: https://github.com/chaos-bodensee/lektor-theme-landed/tree/master/assets/js auch in einer nicht minifizierten Version gibt werden automatisch minifiziert mit dem plugin -> es ist eigentlich nicht nötig, dass da beispielsweise von main.js auch eine minifizierte Version mit im git rumliegt